### PR TITLE
docs: make playground button more concise

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -52,7 +52,7 @@
           "icon": "newspaper"
         },
         {
-          "anchor": "Daydream Playground",
+          "anchor": "Playground",
           "href": "https://daydream.live/?utm_source=comfydocs&utm_medium=referral&utm_campaign=playground_button",
           "icon": "gamepad-modern"
         }


### PR DESCRIPTION
This pull request shortens the playground button so that the sidebar items are more concise.
