### PR TITLE
update ComfyUI installation requirements for hiddenswitch

### DIFF
--- a/technical/get-started/install.mdx
+++ b/technical/get-started/install.mdx
@@ -29,7 +29,10 @@ If you already have ComfyUI installed, the easiest way to install ComfyStream is
 
 <Steps>
   <Step title="Install ComfyUI (if needed)">
-    Download and install [ComfyUI](https://www.comfy.org/download) if you haven't already.
+    Download and install [ComfyUI](https://github.com/hiddenswitch/ComfyUI?tab=readme-ov-file#installing) if you haven't already.
+    <Note>
+    Currently **comfystream** works only with the [hiddenswitch fork](https://github.com/hiddenswitch/ComfyUI) of ComfyUI, the team is actively working add full support for [official ComfyUI](https://github.com/comfyanonymous/ComfyUI).
+    </Note>
   </Step>
   <Step title="Install ComfyUI Manager (if needed)">
     Follow the [ComfyUI Manager installation guide](https://docs.comfy.org/essentials/core-concepts/nodes#installing-the-manager) if you haven't already.


### PR DESCRIPTION
added link to the hiddenswitch installation documentation and added note with info that the current comfystream works only with the forked hiddenswitch version.