### PR TITLE
docs: fix broken links and add workflow type callout box

### DIFF
--- a/technical/get-started/introduction.mdx
+++ b/technical/get-started/introduction.mdx
@@ -31,7 +31,7 @@ To get started, follow the installation guide below or explore the stream pack f
   <Card
     title="Install ComfyStream"
     icon="download"
-    href="install"
+    href="/technical/get-started/install"
   >
     Step-by-step instructions to install ComfyStream and start creating
     real-time workflows.

--- a/technical/get-started/quickstart.mdx
+++ b/technical/get-started/quickstart.mdx
@@ -4,7 +4,7 @@ description: "Run your first real-time AI workflow with ComfyStream and see it l
 icon: "play"
 ---
 
-After you have successfully installed ComfyStream by following the [installation guide](install), you can run your first AI workflow.
+After you have successfully installed ComfyStream by following the [installation guide](/technical/get-started/install), you can run your first AI workflow.
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ Download [example workflows](https://github.com/livepeer/comfystream/tree/main/w
   </Accordion>
 
   <Accordion title="Standalone Browser Tab">
-    If you prefer to run workflows in a new tab rather than inside ComfyUI, click **Open ComfyStream UI** from the [ComfyStream Menu](install#accessing-comfystream).
+    If you prefer to run workflows in a new tab rather than inside ComfyUI, click **Open ComfyStream UI** from the [ComfyStream Menu](/technical/get-started/install#accessing-comfystream).
     This will open a similar dialog box in a new browser tab.
   </Accordion>
 </AccordionGroup>
@@ -33,6 +33,13 @@ Download [example workflows](https://github.com/livepeer/comfystream/tree/main/w
 </Note>
 
 ## Running Your First Workflow
+
+<Info>
+  ComfyStream currently supports only the API workflow format. To export a
+  workflow in this format, use **Workflow > Export (API)** in ComfyUI. Support
+  for the native ComfyUI format is under development and will be available in a
+  future release.
+</Info>
 
 <Steps>
   <Step title="Select your workflow">


### PR DESCRIPTION
This pull request fixes some broken links and adds a callout box that states that Comfystream only supports the API workflow format right now.
