### PR TITLE
docs: Remove Linux/WSL prefix from docker run command in installation docs

### DIFF
--- a/technical/get-started/install.mdx
+++ b/technical/get-started/install.mdx
@@ -150,7 +150,7 @@ First, install the required system software:
   </Step>
   <Step title="Run the container">
     ```bash
-    Linux/WSL docker run -it --gpus all \
+    docker run -it --gpus all \
       -p 8188:8188 \
       -p 8889:8889 \
       -p 5678:5678 \


### PR DESCRIPTION
This fixes a typo in the docs to remove Linux WSL prefix in the docker run command.