### PR TITLE
docs: Update manual installation steps

### DIFF
--- a/technical/get-started/install.mdx
+++ b/technical/get-started/install.mdx
@@ -58,12 +58,19 @@ If you already have ComfyUI installed, the easiest way to install ComfyStream is
 <Accordion title="Manual Installation (Alternative)">
   If you prefer to install ComfyStream manually instead of using the Manager, follow these steps:
   ```bash
-  cd /path/to/ComfyUI/custom_nodes/
-  git clone https://github.com/livepeer/comfystream.git
-  cd comfystream
-  pip install -r requirements.txt
+  git clone https://github.com/hiddenswitch/ComfyUI
+  cd ComfyUI && pip install -e .
+  cd custom_nodes/
+  git clone https://github.com/livepeer/comfystream.git && cd comfystream/
+  pip install -e .
+  python install.py ## this will install the webui files for comfystream 
   ```
-  After completing the installation, restart ComfyUI to load the new custom node.
+  After completing the installation, navigate to the root of the ComfyUI directory.
+  ```bash
+  cd ComfyUI
+  python main.py --listen --front-end-version Comfy-Org/ComfyUI_frontend@latest
+  ```
+  This will start the ComfyUI server with ComfyStream installed.
 </Accordion>
 {/* <!-- prettier-ignore-end --> */}
 


### PR DESCRIPTION
This change add the detailed instuctions for manual installation of hiddenswitch comfyUI and comfystream. Also added instructions to run the install.py script in the comfystream directory to install the web static files for comfystreamui which were not installed with comfystream.