### PR TITLE
docs: Add troubleshooting guide for RunPod connection issues

### DIFF
--- a/technical/get-started/quickstart.mdx
+++ b/technical/get-started/quickstart.mdx
@@ -85,7 +85,7 @@ Download [example workflows](https://github.com/livepeer/comfystream/tree/main/w
 </Accordion>
 
 <Accordion title="Issue connecting to comfystream when using runpod">
-   If you encounter issue when starting comystream in runpod 
+   If you encounter the following error when starting a stream on RunPod:
    ``` bash
    Error proxying offer: Cannot connect to host localhost:8889 ssl:default [Connect call failed ('127.0.0.1', 8889)]
    ```


### PR DESCRIPTION
This change adds information on the troubleshooting section of the documentation to check the settings for streamURL and server settings. 