### PR TITLE
docs: Update installation docs and clarify ComfyStream as a custom node

### DIFF
--- a/technical/get-started/install.mdx
+++ b/technical/get-started/install.mdx
@@ -6,6 +6,10 @@ icon: "download"
 
 ComfyStream is available as a custom node through the [ComfyUI Manager](https://registry.comfy.org/nodes/comfystream) or as a Docker image. Follow the method that best suits your setup.
 
+<Tip>
+You can also install Comfystream by cloning the repository into your ComfyUI/custom_nodes folder — see [Manual Installation](/technical/get-started/install#manual-installation-cloning-repository) for details.
+</Tip>
+
 <CardGroup cols={2}>
   <Card
     title="ComfyUI Manager (Recommended)"
@@ -55,8 +59,8 @@ If you already have ComfyUI installed, the easiest way to install ComfyStream is
 
 {/* <!-- prettier-ignore-start --> */}
 
-<Accordion title="Manual Installation (Alternative)">
-  If you prefer to install ComfyStream manually instead of using the Manager, follow these steps:
+<Accordion title="Manual Installation (Cloning Repository)">
+  If you prefer to install ComfyStream manually by cloning the repository instead of using the Manager, follow these steps:
   ```bash
   cd /path/to/ComfyUI/custom_nodes/
   git clone https://github.com/livepeer/comfystream.git

--- a/technical/get-started/introduction.mdx
+++ b/technical/get-started/introduction.mdx
@@ -16,7 +16,7 @@ icon: "rocket"
 
 ## Overview
 
-The **ComfyStream toolkit** adds powerful real-time video and audio capabilities to [ComfyUI](https://www.comfy.org/), making it easy to build interactive, AI-powered media workflows. It extends ComfyUI with specialized tools for streaming, live processing, and on-the-fly workflow updates, including:
+**ComfyStream is a custom node** that adds powerful real-time video and audio capabilities to [ComfyUI](https://www.comfy.org/), making it easy to build interactive, AI-powered media workflows. It extends ComfyUI with specialized tools for streaming, live processing, and on-the-fly workflow updates, including:
 
 - **[ComfyStream](https://github.com/livepeer/comfystream)** – A custom node that streams audio and video from your webcam and microphone into ComfyUI for real-time AI processing, then returns the processed output.
 - **[ComfyUI-Stream-Pack](https://github.com/livepeer/ComfyUI-Stream-Pack)** – A collection of custom nodes designed to support advanced real-time audio and video workflows.


### PR DESCRIPTION
This change add clarity for comfysteam as a custom node and also makes the option of installing comfystream by cloning repositiory into custom_nodes more clear.

This resolves the issue in linear https://linear.app/livepeer/issue/COMFY-68/highlight-that-comfystream-is-custom-node