### PR TITLE
docs: add obs streaming experimental admonition

### DIFF
--- a/technical/get-started/streaming.mdx
+++ b/technical/get-started/streaming.mdx
@@ -4,6 +4,12 @@ description: "Stream your real-time AI workflows using OBS and browser source fr
 icon: "video"
 ---
 
+<Warning>
+  This is an experimental feature currently available on the [obs-separate-tab
+  branch](https://github.com/livepeer/comfystream/tree/obs-separate-tab). It
+  will be merged into the main branch soon.
+</Warning>
+
 After setting up ComfyStream and running your first workflow, you can use OBS Studio to capture and broadcast your AI-enhanced streams to your favourite platforms — whether it's YouTube, Twitch, or distributed infrastructure providers like Livepeer.
 
 ## Prerequisites


### PR DESCRIPTION
This pull request ensures that people are aware that the OBS streaming feature is not yet merged into the main branch but still lives on a feature banch.
