### PR TITLE
docs: improve ansible port instructions

### DIFF
--- a/technical/custom-nodes/stream-pack/overview.mdx
+++ b/technical/custom-nodes/stream-pack/overview.mdx
@@ -22,8 +22,6 @@ The ComfyUI-Stream-Pack provides a [custom node pack](https://github.com/livepee
 
 To use the StreamPack nodes, you need to install the StreamPack repository in your ComfyUI setup.
 
-{/* <!-- prettier-ignore-start --> */}
-
 <Steps>
   <Step title="Navigate to the custom_nodes directory">
     Open a terminal and navigate to the `custom_nodes` directory in your ComfyUI workspace:
@@ -48,8 +46,8 @@ To use the StreamPack nodes, you need to install the StreamPack repository in yo
   <Step title="Restart ComfyUI">
     Restart your ComfyUI server to load the new nodes.
   </Step>
+
 </Steps>
-{/* <!-- prettier-ignore-end --> */}
 
 ## StreamPack Nodes Overview
 

--- a/technical/get-started/install.mdx
+++ b/technical/get-started/install.mdx
@@ -224,8 +224,11 @@ Use [Ansible](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_i
   </Step>
   <Step title="Open required ports">
     Allow incoming traffic on:
-    - **22** (SSH)  
-    - **8189** (ComfyStream HTTPS)  
+    - **22** (SSH – internal port)
+    - **8189** (ComfyStream HTTPS – internal port)
+    <Note>
+      Ensure your cloud provider maps these to **public ports**. Internal port **8189** is proxied to **8188**, which serves the ComfyUI interface.
+    </Note>
   </Step>
   <Step title="Install Ansible">
     Install Ansible on your **local machine** (not the VM). See the [official installation guide](https://docs.ansible.com/ansible/latest/installation_guide/index.html).
@@ -269,10 +272,7 @@ Use [Ansible](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_i
     </Info>
   </Step>
   <Step title="Open ComfyUI">
-    Visit `https://<VM_IP>:8189` in your browser.  
-    <Note>
-      Port **8189** is used instead of 8188 due to reverse proxy routing.
-    </Note>
+    Visit `https://<VM_IP>:<PUBLIC_COMFYUI_PORT>` in your browser.
   </Step>
 </Steps>
 


### PR DESCRIPTION
This pull request ensures that users are aware that they should use the public ports set in the cloud provider to connect to the ComfyUI interface.