### PR TITLE
docs: add FasterLivePortrait node documentation with TensorRT support

### DIFF
--- a/technical/custom-nodes/third-party-nodes.mdx
+++ b/technical/custom-nodes/third-party-nodes.mdx
@@ -57,4 +57,15 @@ Task-specific nodes are designed for specialized workflows, such as depth estima
     <GitHubFooter url="https://github.com/yuvraj108c/ComfyUI-Depth-Anything-Tensorrt"/>
 
   </Accordion>
+
+  <Accordion header="Faster LivePortrait" title="Faster LivePortrait">
+    Liveportrait implementation with TensorRT engines for faster inference. Follow the documentation in the github repository to first build the docker image and engines.
+
+     These engines will be saved locally and will be reused when running a FasterLivePortrait workflow. 
+    <Tip>
+      Explore the [Example Workflow](https://github.com/livepeer/comfystream/blob/main/workflows/comfystream/live-portrait-daydream.json).
+    </Tip>
+
+    <GitHubFooter url="https://github.com/pschroedl/ComfyUI-FasterLivePortrait"/>
+  </Accordion> 
 </AccordionGroup>


### PR DESCRIPTION
This PR adds the documentation for FasterLivePortrait in the third-party nodes with link to github repo and example workflow